### PR TITLE
Scrutinzer cleanup

### DIFF
--- a/src/Relations/RelationLoader.php
+++ b/src/Relations/RelationLoader.php
@@ -2,7 +2,6 @@
 
 namespace Rexlabs\Laravel\Smokescreen\Relations;
 
-use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Collection;
 use Rexlabs\Smokescreen\Relations\RelationLoaderInterface;
 use Rexlabs\Smokescreen\Resource\ResourceInterface;

--- a/src/Relations/RelationLoader.php
+++ b/src/Relations/RelationLoader.php
@@ -16,11 +16,11 @@ class RelationLoader implements RelationLoaderInterface
     public function load(ResourceInterface $resource)
     {
         // Eager load relationships on collections
-        $obj = $resource->getData();
-        if ($obj instanceof Collection || $obj instanceof Paginator) {
+        $resourceData = $resource->getData();
+        if ($resourceData instanceof Collection) {
             $keys = $this->getRelationshipKeys($resource);
             if (!empty($keys)) {
-                $obj->load($keys);
+                $resourceData->load($keys);
             }
         }
     }

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -377,7 +377,7 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
             $this->smokescreen->parseIncludes($this->includes);
         } elseif ($this->autoParseIncludes) {
             // If autoParseIncludes is not false, then try to parse from the request object.
-            $this->smokescreen->parseIncludes((string)$this->request()->input($this->getIncludeKey()));
+            $this->smokescreen->parseIncludes((string) $this->request()->input($this->getIncludeKey()));
         } else {
             // Empty includes
             $this->smokescreen->parseIncludes('');

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -108,13 +108,13 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
     {
         switch ($this->determineResourceType($data)) {
             case self::TYPE_ITEM_RESOURCE:
-                $this->item($data, $transformer);
+                $this->item($data, $transformer, $resourceKey);
                 break;
             case self::TYPE_COLLECTION_RESOURCE:
-                $this->collection($data, $transformer);
+                $this->collection($data, $transformer, $resourceKey);
                 break;
             default:
-                $this->item($data, $transformer);
+                $this->item($data, $transformer, $resourceKey);
                 break;
         }
 
@@ -377,7 +377,7 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
             $this->smokescreen->parseIncludes($this->includes);
         } elseif ($this->autoParseIncludes) {
             // If autoParseIncludes is not false, then try to parse from the request object.
-            $this->smokescreen->parseIncludes($this->request()->input($this->getIncludeKey()));
+            $this->smokescreen->parseIncludes((string)$this->request()->input($this->getIncludeKey()));
         } else {
             // Empty includes
             $this->smokescreen->parseIncludes('');


### PR DESCRIPTION
- Relationship loader should not handle pagination objects
- Resource key was not passed to item() and collection() methods from transform.
- Ensure parseIncludes() receives a string value