### PR TITLE
Add inject() to inject meta/data into the payload output

### DIFF
--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -329,11 +329,11 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Laravel\Smokescreen\Exceptions\UnresolvedTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
+     * @throws \Rexlabs\Smokescreen\Exception\IncludeException
      *
      * @return array
      *
      * @see Smokescreen::toArray()
-     * @throws \Rexlabs\Smokescreen\Exception\IncludeException
      */
     public function jsonSerialize(): array
     {
@@ -343,8 +343,9 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
     /**
      * Inject some data into the payload under given key (supports dot-notation).
      * This method can be called multiple times.
+     *
      * @param string $key
-     * @param mixed $data
+     * @param mixed  $data
      *
      * @return $this
      */
@@ -363,9 +364,9 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
      * @throws \Rexlabs\Laravel\Smokescreen\Exceptions\UnresolvedTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
+     * @throws \Rexlabs\Smokescreen\Exception\IncludeException
      *
      * @return array
-     * @throws \Rexlabs\Smokescreen\Exception\IncludeException
      */
     public function toArray(): array
     {
@@ -445,7 +446,7 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
         // If no model can be determined from the data
         if ($model === null) {
             // Don't assign any transformer for this data
-            return null;
+            return;
         }
 
         // Cool, now let's try to find a matching transformer based on our Model class

--- a/tests/Unit/SmokescreenTest.php
+++ b/tests/Unit/SmokescreenTest.php
@@ -451,7 +451,8 @@ class SmokescreenTest extends TestCase
 
     public function test_default_serializer_can_be_configured_with_object()
     {
-        $obj = new class extends DefaultSerializer {};
+        $obj = new class() extends DefaultSerializer {
+        };
         $stub = $this->getMockBuilder(Smokescreen::class)
             ->setMethods(['serializeWith'])
             ->disableOriginalConstructor()
@@ -705,9 +706,9 @@ class SmokescreenTest extends TestCase
         $this->assertEquals([
                 'data' => [
                     [
-                        'id'    => 1,
-                        'title' => 'Example post 1',
-                        'body'  => 'An example post',
+                        'id'           => 1,
+                        'title'        => 'Example post 1',
+                        'body'         => 'An example post',
                         'new_property' => 'val',
                     ],
                     [
@@ -720,8 +721,8 @@ class SmokescreenTest extends TestCase
                     'pagination' => [
                         'next' => 'test1',
                         'prev' => 'test2',
-                    ]
-                ]
+                    ],
+                ],
             ],
             $smokescreen->toArray()
         );

--- a/tests/Unit/SmokescreenTest.php
+++ b/tests/Unit/SmokescreenTest.php
@@ -676,4 +676,54 @@ class SmokescreenTest extends TestCase
                 ]
             );
     }
+
+    public function test_can_inject_data_into_payload()
+    {
+        $data = [
+            [
+                'id'    => 1,
+                'title' => 'Example post 1',
+                'body'  => 'An example post',
+            ],
+            [
+                'id'    => 2,
+                'title' => 'Example post 2',
+                'body'  => 'Another example post',
+            ],
+        ];
+
+        $smokescreen = Smokescreen::make()
+            ->transform($data, $this->createTransformer())
+            // Add a a pagination array nested under meta
+            ->inject('meta.pagination', [
+                'next' => 'test1',
+                'prev' => 'test2',
+            ])
+            // Insert a property into the first element in the collection
+            ->inject('data.0.new_property', 'val');
+
+        $this->assertEquals([
+                'data' => [
+                    [
+                        'id'    => 1,
+                        'title' => 'Example post 1',
+                        'body'  => 'An example post',
+                        'new_property' => 'val',
+                    ],
+                    [
+                        'id'    => 2,
+                        'title' => 'Example post 2',
+                        'body'  => 'Another example post',
+                    ],
+                ],
+                'meta' => [
+                    'pagination' => [
+                        'next' => 'test1',
+                        'prev' => 'test2',
+                    ]
+                ]
+            ],
+            $smokescreen->toArray()
+        );
+    }
 }


### PR DESCRIPTION
## Feature: data injection

Provides an `inject($key, $data)` method which makes it possible to add _injections_ which will be included in the final transformed payload when the transformation process occurs.   This makes it simple to add additional meta data to your payload for additional properties that do not usually belong in your transformer.

Note that `$key` supports dot-notation for depth based properties.  The full path will be automatically created as needed.