### PR TITLE
Bulk transformers generation

### DIFF
--- a/config/smokescreen.php
+++ b/config/smokescreen.php
@@ -8,6 +8,9 @@ return [
     // Set the transformer name when mapping models to transformers.
     'transformer_name' => '{ModelName}Transformer',
 
+    // Set the directory where your application models can be found.
+    'models_directory' => 'app/',
+
     // Override the default serializer to be used.
     // If not specified - the Smokescreen DefaultSerializer will be used.
     'default_serializer' => null,

--- a/src/Console/MakeTransformerCommand.php
+++ b/src/Console/MakeTransformerCommand.php
@@ -11,13 +11,14 @@ class MakeTransformerCommand extends GeneratorCommand
 {
     /**
      * The name and signature of the console command.
-     * smokescreen:transformer --for='App\Models\Post'.
+     * make:transformer User
      *
      * @var string
      */
     protected $signature = 'make:transformer
-        {model : The model to transform. e.g. "App\User"} 
-        {--force : Overwrite an existing transformer}';
+        {model? : The name of the model to transform. e.g. User} 
+        {--f|force : Overwrite an existing transformer}
+        {--a|all= : Generate a transformer for all models. You can optionally specify the models directory}';
 
     /**
      * The console command description.
@@ -27,23 +28,11 @@ class MakeTransformerCommand extends GeneratorCommand
     protected $description = 'Create a new smokescreen transformer class';
 
     /**
-     * The type of class being generated.
-     *
-     * @var string
-     */
-    protected $type = 'Transformer';
-
-    /**
      * The view factory.
      *
      * @var \Illuminate\Contracts\View\Factory
      */
     protected $viewFactory;
-
-    /**
-     * @var string
-     */
-    protected $modelClass;
 
     /**
      * Inject the dependencies.
@@ -65,9 +54,52 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     public function handle()
     {
-        $this->modelClass = $this->resolveModelClass($this->argument('model'));
+        $model = $this->getModelName();
+        $this->type = "{$model} transformer";
 
-        parent::handle();
+        if (is_null($this->argument('model'))) {
+            $this->generateAllTransformers();
+        } elseif (!class_exists($this->getModelClass())) {
+            $this->error("The model [{$model}] does not exist.");
+        } elseif (class_exists($this->getTransformerClass()) && !$this->option('force')) {
+            $this->warn("{$this->type} already exists.");
+        } else {
+            parent::handle();
+        }
+    }
+
+    /**
+     * Generate a transformer for every model.
+     *
+     * @return void
+     */
+    protected function generateAllTransformers() : void
+    {
+        $directory = $this->getModelsDirectory();
+        $models = (new ModelsFinder)->findInDirectory($directory);
+
+        foreach ($models as $model) {
+            $this->call('make:transformer', [
+                'model' => class_basename($model),
+                '--force' => $this->option('force'),
+            ]);
+        }
+    }
+
+    /**
+     * Retrieve the models directory.
+     *
+     * @return string
+     */
+    protected function getModelsDirectory() : string
+    {
+        $relativePath = $this->option('all') ?: config('smokescreen.models_directory');
+
+        if (!file_exists($absolutePath = base_path($relativePath))) {
+            exit($this->error("The specified models directory does not exist: {$absolutePath}"));
+        }
+
+        return $absolutePath;
     }
 
     /**
@@ -76,47 +108,6 @@ class MakeTransformerCommand extends GeneratorCommand
     protected function getStub()
     {
         return 'smokescreen::transformer';
-    }
-
-    /**
-     * Given a model name (or namespace) try to resolve the fully qualified model class
-     * while checking common model namespaces.
-     *
-     * @param string $name
-     *
-     * @return mixed|null
-     */
-    protected function resolveModelClass(string $name)
-    {
-        $modelClass = null;
-
-        // If not name-spaced, get a list of classes to search in common model namespaces.
-        $search = strpos($name, '\\') !== false ? [$name] : array_map(function ($directory) use ($name) {
-            return $directory.'\\'.$name;
-        }, ['App\\Models', 'App\\Model', 'App']);
-
-        // Check for a valid class.
-        foreach ($search as $class) {
-            if (class_exists($class)) {
-                $modelClass = $class;
-                break;
-            }
-        }
-
-        // If we didn't find one, exit out.
-        if ($modelClass === null) {
-            throw new \InvalidArgumentException("The model [$name] does not exist, please create it first.");
-        }
-
-        return $modelClass;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $this->getTransformerNamespace();
     }
 
     /**
@@ -138,16 +129,16 @@ class MakeTransformerCommand extends GeneratorCommand
         $modelInspector = new ModelMapper($this->getModel());
 
         return [
-            'model'                => $this->getModel(),
-            'modelClass'           => $this->getModelClass(),
-            'modelNamespace'       => $this->getModelNamespace(),
-            'modelName'            => $this->getModelName(),
-            'transformerClass'     => $this->getTransformerClass(),
+            'model' => $this->getModel(),
+            'modelClass' => $this->getModelClass(),
+            'modelNamespace' => $this->getModelNamespace(),
+            'modelName' => $this->getModelName(),
+            'transformerClass' => $this->getTransformerClass(),
             'transformerNamespace' => $this->getTransformerNamespace(),
-            'transformerName'      => $this->getTransformerName(),
-            'includes'             => $modelInspector->getIncludes(),
-            'properties'           => $modelInspector->getDeclaredProperties(),
-            'defaultProperties'    => $modelInspector->getDefaultProperties(),
+            'transformerName' => $this->getTransformerName(),
+            'includes' => $modelInspector->getIncludes(),
+            'properties' => $modelInspector->getDeclaredProperties(),
+            'defaultProperties' => $modelInspector->getDefaultProperties(),
         ];
     }
 
@@ -156,7 +147,7 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return $this->getTransformerName();
+        return $this->getTransformerClass();
     }
 
     /**
@@ -166,8 +157,11 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected function getTransformerName()
     {
-        return preg_replace('/{ModelName}/i', $this->getModelName(),
-            config('smokescreen.transformer_name', '{ModelName}Transformer'));
+        return preg_replace(
+            '/{ModelName}/i',
+            $this->getModelName(),
+            config('smokescreen.transformer_name', '{ModelName}Transformer')
+        );
     }
 
     /**
@@ -187,7 +181,7 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected function getTransformerClass()
     {
-        return $this->getTransformerNamespace().'\\'.$this->getTransformerName();
+        return $this->getTransformerNamespace() . '\\' . $this->getTransformerName();
     }
 
     /**
@@ -197,7 +191,11 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected function getModelClass(): string
     {
-        return $this->modelClass;
+        $directory = config('smokescreen.models_directory', 'app/');
+        $file = str_finish($directory, '/') . $this->getModelName();
+        $segments = array_map('ucfirst', explode('/', $file));
+
+        return implode('\\', $segments);
     }
 
     /**
@@ -219,7 +217,7 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected function getModelName(): string
     {
-        return class_basename($this->getModelClass());
+        return ucfirst($this->argument('model'));
     }
 
     /**

--- a/src/Console/MakeTransformerCommand.php
+++ b/src/Console/MakeTransformerCommand.php
@@ -70,10 +70,8 @@ class MakeTransformerCommand extends GeneratorCommand
 
     /**
      * Generate a transformer for every model.
-     *
-     * @return void
      */
-    protected function generateAllTransformers() : void
+    protected function generateAllTransformers()
     {
         $directory = $this->getModelsDirectory();
         $models = (new ModelsFinder)->findInDirectory($directory);
@@ -96,7 +94,8 @@ class MakeTransformerCommand extends GeneratorCommand
         $relativePath = $this->option('all') ?: config('smokescreen.models_directory');
 
         if (!file_exists($absolutePath = base_path($relativePath))) {
-            exit($this->error("The specified models directory does not exist: {$absolutePath}"));
+            $this->error("The specified models directory does not exist: {$absolutePath}");
+            exit();
         }
 
         return $absolutePath;

--- a/src/Console/ModelMapper.php
+++ b/src/Console/ModelMapper.php
@@ -150,6 +150,8 @@ class ModelMapper
         if ($type = $this->getResourceTypeByMethodBody($method)) {
             return $type;
         }
+
+        return null;
     }
 
     /**
@@ -165,10 +167,9 @@ class ModelMapper
         $namespace = 'Illuminate\Database\Eloquent\Relations';
 
         if (!starts_with($returnType, $namespace)) {
-            return;
+            return null;
         }
 
-//        $relation = lcfirst(class_basename($returnType));
         $relation = class_basename($returnType);
 
         return $this->relationsMap[$relation] ?? null;
@@ -196,6 +197,8 @@ class ModelMapper
                 }
             }
         }
+
+        return null;
     }
 
     /**
@@ -221,5 +224,7 @@ class ModelMapper
                 }
             }
         }
+
+        return null;
     }
 }

--- a/src/Console/ModelsFinder.php
+++ b/src/Console/ModelsFinder.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rexlabs\Laravel\Smokescreen\Console;
+
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * The models finder.
+ *
+ */
+class ModelsFinder
+{
+    /**
+     * Find the models in the given directory.
+     *
+     * @param string $directory
+     * @return array
+     */
+    public function findInDirectory(string $directory) : array
+    {
+        $models = [];
+        $iterator = Finder::create()->files()->name('*.php')->in($directory)->depth(0)->sortByName();
+
+        foreach ($iterator as $file) {
+            if (!class_exists($class = $this->qualifyClassFromFile($file))) {
+                continue;
+            }
+
+            $isAbstract = (new ReflectionClass($class))->isAbstract();
+            $isModel = is_subclass_of($class, 'Illuminate\Database\Eloquent\Model');
+
+            if ($isModel && !$isAbstract) {
+                $models[] = new $class;
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Retrieve the fully-qualified class name of the given file.
+     *
+     * @param SplFileInfo $file
+     * @return string|null
+     */
+    protected function qualifyClassFromFile(SplFileInfo $file) : ?string
+    {
+        preg_match('/namespace (.*);/', $file->getContents(), $matches);
+
+        if (is_null($namespace = $matches[1] ?? null)) {
+            return null;
+        }
+
+        return $namespace . '\\' . rtrim($file->getFilename(), '.php');
+    }
+}

--- a/src/Console/ModelsFinder.php
+++ b/src/Console/ModelsFinder.php
@@ -6,33 +6,25 @@ use ReflectionClass;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-/**
- * The models finder.
- *
- */
 class ModelsFinder
 {
     /**
      * Find the models in the given directory.
      *
      * @param string $directory
-     * @return array
+     *
+     * @return array|string[]
+     * @throws \ReflectionException
      */
-    public function findInDirectory(string $directory) : array
+    public function findInDirectory(string $directory): array
     {
         $models = [];
         $iterator = Finder::create()->files()->name('*.php')->in($directory)->depth(0)->sortByName();
 
         foreach ($iterator as $file) {
-            if (!class_exists($class = $this->qualifyClassFromFile($file))) {
-                continue;
-            }
-
-            $isAbstract = (new ReflectionClass($class))->isAbstract();
-            $isModel = is_subclass_of($class, 'Illuminate\Database\Eloquent\Model');
-
-            if ($isModel && !$isAbstract) {
-                $models[] = new $class;
+            $class = $this->determineClassFromFile($file);
+            if ($class !== null && class_exists($class) && $this->isModelClass($class)) {
+                $models[] = $class;
             }
         }
 
@@ -43,16 +35,38 @@ class ModelsFinder
      * Retrieve the fully-qualified class name of the given file.
      *
      * @param SplFileInfo $file
+     *
      * @return string|null
      */
-    protected function qualifyClassFromFile(SplFileInfo $file)
+    protected function determineClassFromFile(SplFileInfo $file)
     {
-        preg_match('/namespace (.*);/', $file->getContents(), $matches);
-
-        if (is_null($namespace = $matches[1] ?? null)) {
+        if (!preg_match('/namespace (.*);/', $file->getContents(), $matches)) {
             return null;
         }
 
-        return $namespace . '\\' . rtrim($file->getFilename(), '.php');
+        return $matches[1] . '\\' . rtrim($file->getFilename(), '.php');
+    }
+
+    /**
+     * Determine if the given class is an eloquent model.
+     *
+     * @param string $class
+     *
+     * @return bool
+     * @throws \ReflectionException
+     */
+    protected function isModelClass(string $class): bool
+    {
+        if (!is_subclass_of($class, \Illuminate\Database\Eloquent\Model::class)) {
+            // Must extend Model
+            return false;
+        }
+
+        if ((new ReflectionClass($class))->isAbstract()) {
+            // Exclude abstract classes
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Console/ModelsFinder.php
+++ b/src/Console/ModelsFinder.php
@@ -45,7 +45,7 @@ class ModelsFinder
      * @param SplFileInfo $file
      * @return string|null
      */
-    protected function qualifyClassFromFile(SplFileInfo $file) : ?string
+    protected function qualifyClassFromFile(SplFileInfo $file)
     {
         preg_match('/namespace (.*);/', $file->getContents(), $matches);
 


### PR DESCRIPTION
Enable the following scenarios:

`make:transformer User`
Generate a transformer for User unless it exists already

`make:transformer User --force`
Generate a transformer for User or overwrite it if exists

`make:transformer`
Generate transformers for all models that don't have one

`make:transformer --force`
Generate transformers for all models and overwrite the existing ones

`make:transformer --all`
Generate transformers for all models that don't have one

`make:transformer --all --force`
Generate transformers for all models and overwrite the existing ones

`make:transformer --all=app/Models`
Generate transformers for all models in the `app/Models` directory that don't have one

`make:transformer --all=app/Models --force`
Generate transformers for all models in the `app/Models` directory and overwrite the existing ones