### PR TITLE
Add support for `doctrine/dbal` version `^3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=7.4",
     "rexlabs/smokescreen": "^2.0",
     "laravel/framework": "^8.0",
-    "doctrine/dbal": "^2.5|^2.7"
+    "doctrine/dbal": "^2.5|^2.7|^3.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",


### PR DESCRIPTION
## Feature/Issue Description

Supports the latest version of `doctrine/dbal` to `^3.0`. This will unblock apps that uses this library to make database column modifications with `double` data types.

### Supporting Resources

- [Slack](https://rexsoftware.slack.com/archives/CR0K86U8Y/p1650270567833999)

---

## Summary of changes

- Simply added `^3.0` on the `doctrine/dbal` version in the `composer.json` file.

## Checklist

- [] I have added unit tests for this feature/change
- [x] I have performed thorough manual testing
- [ ] I have added OpenAPI documentation (for any API changes)
- [] I verified that my code complies with GRIP code standards
- [ ] I have included method and argument descriptions (where applicable)

## What's been tested

- Executed unit test on the entire app/package, making sure no functionalities were affected.

## Deployment/Release notes

- No config changes or migrations are needed.

## Blockers

Are there any blockers for this pull request?
- None