### PR TITLE
Fix Option Definitions

### DIFF
--- a/src/Console/MakeTransformerCommand.php
+++ b/src/Console/MakeTransformerCommand.php
@@ -17,9 +17,9 @@ class MakeTransformerCommand extends GeneratorCommand
      */
     protected $signature = 'make:transformer
         {model? : The name of the model to transform. e.g. User} 
-        {-f|--force : Overwrite an existing transformer}
-        {-d|--directory= : Specify the models directory }
-        {-a|--all : Generate a transformer for all models. }';
+        {--f|force : Overwrite an existing transformer}
+        {--d|directory= : Specify the models directory}
+        {--a|all : Generate a transformer for all models.}';
 
     /**
      * The console command description.


### PR DESCRIPTION
The options were defined incorrectly, caused errors to be throw in newer versions of Laravel.

https://laravel.com/docs/11.x/artisan#option-shortcuts