### PR TITLE
Ensure Include Key is Only Pulled From Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog for Laravel Smokescreen
 
+## 4.0.0
+
+- Ensure Include Key is Only Pulled From Query
+
 ## 3.0.1
 
 - Set strict php support for php 7.4-8.3

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -447,7 +447,7 @@ class Smokescreen implements \JsonSerializable, Jsonable, Arrayable, Responsable
         } elseif ($this->autoParseIncludes) {
             // If autoParseIncludes is not false, then try to parse from the
             // request object.
-            $this->smokescreen->parseIncludes((string) $this->request()->input($this->getIncludeKey()));
+            $this->smokescreen->parseIncludes((string) $this->request()->query($this->getIncludeKey()));
         } else {
             // Empty includes
             $this->smokescreen->parseIncludes('');


### PR DESCRIPTION
The custom metrics and custom validation features in PM allow uses to provide includes which are supposed to be used when building the context data. Because those includes are provided as a top level property in the body `input()` grabs them. This PR changes the method used to get the includes from `input` to `query`, as far as I'm aware we only want to be getting the includes from the query string. 